### PR TITLE
Update devDependencies: @types/node 20→22, TypeScript 4→5

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
-    "@types/node": "^20.x",
+    "@types/node": "^22.x",
     "rimraf": "^5.0.0",
-    "typescript": "^4.0.0"
+    "typescript": "^5.0.0"
   },
   "main": "dist/src/index.js"
 }


### PR DESCRIPTION
## Summary

Update TypeScript MCP template devDependencies to match Node.js 22 runtime.

## Changes

| Package | From | To |
|---------|------|-----|
| `@types/node` | `^20.x` | `^22.x` |
| `typescript` | `^4.0.0` | `^5.0.0` |

## Why These Changes?

| Change | Reason |
|--------|--------|
| `@types/node` 20→22 | Type definitions should match runtime version (Node 22) |
| `typescript` 4→5 | Latest stable with better performance and features |

Fixes #38