### PR TITLE
Fix VS Code F5 startup and add Bicep resource group output

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "azureFunctions.deploySubpath": ".",
+    "azureFunctions.deploySubpath": "mcp-weather-app",
     "azureFunctions.postDeployTask": "npm install (functions)",
     "azureFunctions.projectLanguage": "TypeScript",
     "azureFunctions.projectRuntime": "~4",
@@ -9,5 +9,6 @@
     "files.exclude": {
         "obj": true,
         "bin": true
-    }
+    },
+    "azureFunctions.defaultFunctionAppPath": "mcp-weather-app"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,14 +7,20 @@
       "command": "host start",
       "problemMatcher": "$func-node-watch",
       "isBackground": true,
-      "dependsOn": "npm watch (functions)"
+      "dependsOn": "npm watch (functions)",
+      "options": {
+        "cwd": "${workspaceFolder}/mcp-weather-app"
+      }
     },
     {
       "type": "shell",
       "label": "npm build (functions)",
       "command": "npm run build",
       "dependsOn": "npm clean (functions)",
-      "problemMatcher": "$tsc"
+      "problemMatcher": "$tsc",
+      "options": {
+        "cwd": "${workspaceFolder}/mcp-weather-app"
+      }
     },
     {
       "type": "shell",
@@ -26,19 +32,28 @@
         "kind": "build",
         "isDefault": true
       },
-      "isBackground": true
+      "isBackground": true,
+      "options": {
+        "cwd": "${workspaceFolder}/mcp-weather-app"
+      }
     },
     {
       "type": "shell",
       "label": "npm install (functions)",
-      "command": "npm install"
+      "command": "npm install",
+      "options": {
+        "cwd": "${workspaceFolder}/mcp-weather-app"
+      }
     },
     {
       "type": "shell",
       "label": "npm prune (functions)",
       "command": "npm prune --production",
       "dependsOn": "npm build (functions)",
-      "problemMatcher": []
+      "problemMatcher": [],
+      "options": {
+        "cwd": "${workspaceFolder}/mcp-weather-app"
+      }
     },
     {
       "type": "shell",
@@ -47,7 +62,10 @@
       "dependsOn": [
         "func: extensions install",
         "npm install (functions)"
-      ]
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/mcp-weather-app"
+      }
     }
   ]
 }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -263,6 +263,7 @@ module monitoring 'br/public:avm/res/insights/component:0.6.0' = {
 // App outputs
 output APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.connectionString
 output AZURE_LOCATION string = location
+output AZURE_RESOURCE_GROUP string = rg.name
 output AZURE_TENANT_ID string = tenant().tenantId
 output SERVICE_API_NAME string = api.outputs.SERVICE_API_NAME
 output SERVICE_API_DEFAULT_HOSTNAME string = api.outputs.SERVICE_MCP_DEFAULT_HOSTNAME


### PR DESCRIPTION
- Adds `AZURE_RESOURCE_GROUP` Bicep output for post-provision hooks
- Fixes `.vscode/settings.json`: updates `deploySubpath` to `mcp-weather-app` and adds `defaultFunctionAppPath`
- Fixes `.vscode/tasks.json`: adds `cwd` to all tasks pointing to `mcp-weather-app`